### PR TITLE
hide_nav

### DIFF
--- a/_includes/templates/_toctree.liquid
+++ b/_includes/templates/_toctree.liquid
@@ -17,7 +17,7 @@
 <ul>
   {% comment %} list file {% endcomment %}
   {%- for dkitem in workdir_pages -%}
-  {%- unless dkitem.redirect_to or dkitem.hide_nav -%}
+  {%- unless dkitem.redirect_to or dkitem.nav_exclude -%}
     {%- if dkitem.dir == dkitem.url -%}
       {%- assign level = dkitem.dir | append: "temp" | replace_first: "/", "" | split: "/" | size | minus: 2 %}
       <li class="toc level-{{ level }}">{% include templates/_toctree.liquid workdir=dkitem.dir %}</li>

--- a/_includes/templates/_toctree.liquid
+++ b/_includes/templates/_toctree.liquid
@@ -17,7 +17,7 @@
 <ul>
   {% comment %} list file {% endcomment %}
   {%- for dkitem in workdir_pages -%}
-  {%- unless dkitem.redirect_to -%}
+  {%- unless dkitem.redirect_to or dkitem.hide_nav -%}
     {%- if dkitem.dir == dkitem.url -%}
       {%- assign level = dkitem.dir | append: "temp" | replace_first: "/", "" | split: "/" | size | minus: 2 %}
       <li class="toc level-{{ level }}">{% include templates/_toctree.liquid workdir=dkitem.dir %}</li>

--- a/_includes/templates/toctree.liquid
+++ b/_includes/templates/toctree.liquid
@@ -3,7 +3,7 @@
 {% comment %} list the root files {% endcomment %}
 <ul>
     {%- for item in workdir_files -%}
-    {%- unless item.redirect_to  -%}
+    {%- unless item.redirect_to or item.hide_nav  -%}
         {%- assign level = item.dir | append: "temp" | replace_first: "/", "" | split: "/" | size -%}
         {%- capture current -%}
             {%- if page.url == item.url %}current{% endif -%}

--- a/_includes/templates/toctree.liquid
+++ b/_includes/templates/toctree.liquid
@@ -3,7 +3,7 @@
 {% comment %} list the root files {% endcomment %}
 <ul>
     {%- for item in workdir_files -%}
-    {%- unless item.redirect_to or item.hide_nav  -%}
+    {%- unless item.redirect_to or item.nav_exclude  -%}
         {%- assign level = item.dir | append: "temp" | replace_first: "/", "" | split: "/" | size -%}
         {%- capture current -%}
             {%- if page.url == item.url %}current{% endif -%}


### PR DESCRIPTION
just like just-the-docs [feature](https://just-the-docs.github.io/just-the-docs/docs/navigation-structure/#excluding-pages) 
Excluding pages

For specific pages that you do not wish to include in the main navigation, e.g. a 404 page or a landing page, use the nav_exclude: true parameter in the YAML front matter for that page.

```
---
nav_exclude: true
---
```